### PR TITLE
Include teensy check when checking for FS support.

### DIFF
--- a/src/ArduinoYaml.hpp
+++ b/src/ArduinoYaml.hpp
@@ -58,7 +58,7 @@ extern "C"
 
 #define I18N_SUPPORT
 
-#if __has_include(<FS.h>)
+#if __has_include(<FS.h>) && !defined CORE_TEENSY
   #define I18N_SUPPORT_FS
 #endif
 


### PR DESCRIPTION
Teensy has an include file FS.h which triggers the i18n filesystem support, but teensy filesystem is not compatible with the ESP FS code (at least in namespace). This pull requests disables the standard FS.h check when compiling for teensy.